### PR TITLE
Fix slicing logic in parseMessageWithEmotes

### DIFF
--- a/src/modules/message/emotes/parseMessageWithEmotes.ts
+++ b/src/modules/message/emotes/parseMessageWithEmotes.ts
@@ -25,7 +25,7 @@ export const parseMessageWithEmotes = (fields : any) => {
     i = end + 1;
   });
 
-  i < rawMessage.length && newMessage.push(createFragment(rawMessage.substring(i, rawMessage.length)));
+  i < rawMessage.length && newMessage.push(createFragment(rawMessage.substring(i)));
 
   return groupElements(newMessage);
 };


### PR DESCRIPTION
- Se soluciono problema por el cual el mensaje no se mostraba correctamente si habian emotes antes del texto
![image](https://github.com/user-attachments/assets/dddf1576-7da3-4b36-a7fb-1699e0e3b9c9)

 
