### PR TITLE
fix: corregir interfaz BadgeJSONInfoType para que coincida con la estructura real de datos

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 // Cliente principal
 export { client } from "./mtmi.ts";
 
+// Opciones y configuración
+export type { OptionsObject, BadgeJSONInfoType } from "./mtmi.ts";
+
 // Tipos del mapa de eventos
 export type { EventType, EventTypeMap } from "./types.ts";
 

--- a/src/mtmi.ts
+++ b/src/mtmi.ts
@@ -22,10 +22,10 @@ export interface OptionsObject {
 }
 
 export interface BadgeJSONInfoType {
-  /** Nombre del badge. */
-  name: string,
+  /** Identificador del badge en formato "nombre/valor" (ej: "subscriber/12"). */
+  text: string,
   /** Valor asociado al badge. */
-  value: string,
+  value: string | number,
   /** Imagen identificativa del badge. */
   image: string,
   /** Descripción del badge. */


### PR DESCRIPTION
## Problema

Error de TypeScript al pasar badges a `client.connect()`:

```
Type 'Badges' is not assignable to type 'BadgeJSONInfoType[]'.
Property 'name' is missing in type 'Badge' but required in type 'BadgeJSONInfoType'.
```

Este error ocurría tanto al usar los badges JSON incluidos en MTMI como al usar paquetes externos como `mtmi-async-badges`.

## Causa raíz

1. La interfaz `BadgeJSONInfoType` usaba la propiedad `name`, pero los datos JSON reales y el código usan `text`
2. La interfaz no se exportaba, impidiendo la verificación de tipos en proyectos que consumen MTMI

## Solución

- Cambiado propiedad `name` a `text` para coincidir con la estructura JSON real
- Cambiado tipo de `value` de `string` a `string | number` para mayor flexibilidad
- Exportados los tipos `BadgeJSONInfoType` y `OptionsObject` para uso externo

## Pruebas

- ✅ El build pasa sin errores
- ✅ Compatible con `badges.json` de MTMI
- ✅ Compatible con el paquete `mtmi-async-badges`
- ✅ Tipos correctamente exportados en las definiciones compiladas

## Archivos modificados

- `src/mtmi.ts` - Actualizada definición de la interfaz
- `src/index.ts` - Exportados tipos para uso público